### PR TITLE
pass permissions mode when hydrating directories

### DIFF
--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/ProjFS.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/ProjFS.cs
@@ -38,9 +38,9 @@ namespace PrjFSLib.Linux.Interop
             _Stop(this.handle);
         }
 
-        public Result CreateProjDir(string relativePath)
+        public Result CreateProjDir(string relativePath, ushort fileMode)
         {
-            return _CreateProjDir(this.handle, relativePath).ConvertErrnoToResult();
+            return _CreateProjDir(this.handle, relativePath, fileMode).ConvertErrnoToResult();
         }
 
         public Result CreateProjFile(string relativePath, ulong fileSize, ushort fileMode)
@@ -73,7 +73,7 @@ namespace PrjFSLib.Linux.Interop
         private static extern IntPtr _Stop(IntPtr fs);
 
         [DllImport(PrjFSLibPath, EntryPoint = "projfs_create_proj_dir")]
-        private static extern Errno _CreateProjDir(IntPtr fs, string relativePath);
+        private static extern Errno _CreateProjDir(IntPtr fs, string relativePath, ushort fileMode);
 
         [DllImport(PrjFSLibPath, EntryPoint = "projfs_create_proj_file")]
         private static extern Errno _CreateProjFile(IntPtr fs, string relativePath, ulong fileSize, ushort fileMode);

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -108,7 +108,7 @@ namespace PrjFSLib.Linux
         public virtual Result WritePlaceholderDirectory(
             string relativePath)
         {
-            return this.projfs.CreateProjDir(relativePath);
+            return this.projfs.CreateProjDir(relativePath, Convert.ToUInt16("0777", 8));
         }
 
         public virtual Result WritePlaceholderFile(


### PR DESCRIPTION
This change requires a concomitant change the libprojfs API to accept a mode_t parameter in `projfs_create_proj_dir()`; see github/libprojfs#55 for details.