### PR TITLE
implement local file IO write loop for hydration

### DIFF
--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/ProjFS.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/ProjFS.cs
@@ -53,11 +53,6 @@ namespace PrjFSLib.Linux.Interop
             return _CreateProjSymlink(this.handle, relativePath, symlinkTarget).ConvertErrnoToResult();
         }
 
-        public Result WriteFileContents(int fd, IntPtr bytes, ulong byteCount)
-        {
-            return _WriteFileContents(fd, bytes, byteCount).ConvertErrnoToResult();
-        }
-
         [DllImport(PrjFSLibPath, EntryPoint = "projfs_new")]
         private static extern IntPtr _New(
             string lowerdir,
@@ -80,9 +75,6 @@ namespace PrjFSLib.Linux.Interop
 
         [DllImport(PrjFSLibPath, EntryPoint = "projfs_create_proj_symlink")]
         private static extern Errno _CreateProjSymlink(IntPtr fs, string relativePath, string symlinkTarget);
-
-        [DllImport(PrjFSLibPath, EntryPoint = "projfs_write_file_contents")]
-        private static extern Errno _WriteFileContents(int fd, IntPtr bytes, ulong byteCount);
 
         [StructLayout(LayoutKind.Sequential)]
         public struct Event

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -76,14 +76,25 @@ namespace PrjFSLib.Linux
         {
             unsafe
             {
-                fixed (byte* buffer = bytes)
-                {
-                    return this.projfs.WriteFileContents(
-                        fd,
-                        (IntPtr)buffer,
-                        byteCount);
+                 fixed (byte* bytesPtr = bytes)
+                 {
+                     byte* bytesToWrite = bytesPtr;
+
+                     while (byteCount > 0)
+                     {
+                        long res = Syscall.write(fd, bytesToWrite, byteCount);
+                        if (res == -1)
+                        {
+                            return Result.EIOError;
+                        }
+
+                        bytesToWrite += res;
+                        byteCount -= (uint)res;
+                    }
                 }
             }
+
+            return Result.Success;
         }
 
         public virtual Result DeleteFile(


### PR DESCRIPTION
Rather than calling down into the libprojfs API to write bytes to a file during hydration, we can utilize the `Mono.Unix.Native.Syscall` `write(2)` wrapper and perform this loop the C# layer in our `ProjFS.Linux` `WriteFileContents()` method.

There should be no impact on performance as we are, in either case, calling via P/Invoke into a dynamic library (our `libprojfs.so` or Mono's `.dll`) to actually perform the `write(2)` call.

However, this approach avoids the need to implement a generic write loop function in libprojfs and thus helps simplify that library's API.

See also github/libprojfs#59 for the corresponding changes in libprojfs.