### PR TITLE
Use projection attributes for content and provider IDs

### DIFF
--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/ProjFS.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/ProjFS.cs
@@ -79,14 +79,14 @@ namespace PrjFSLib.Linux.Interop
                     {
                         new Attr
                         {
-                            Name = this.providerIdAttrNamePtr,
-                            Value = (IntPtr)providerIdPtr,
+                            Name = (byte*)this.providerIdAttrNamePtr,
+                            Value = providerIdPtr,
                             Size = providerId.Length
                         },
                         new Attr
                         {
-                            Name = this.contentIdAttrNamePtr,
-                            Value = (IntPtr)contentIdPtr,
+                            Name = (byte*)this.contentIdAttrNamePtr,
+                            Value = contentIdPtr,
                             Size = contentId.Length
                         }
                     };
@@ -125,14 +125,14 @@ namespace PrjFSLib.Linux.Interop
                     {
                         new Attr
                         {
-                            Name = this.providerIdAttrNamePtr,
-                            Value = (IntPtr)providerIdPtr,
+                            Name = (byte*)this.providerIdAttrNamePtr,
+                            Value = providerIdPtr,
                             Size = providerId.Length
                         },
                         new Attr
                         {
-                            Name = this.contentIdAttrNamePtr,
-                            Value = (IntPtr)contentIdPtr,
+                            Name = (byte*)this.contentIdAttrNamePtr,
+                            Value = contentIdPtr,
                             Size = contentId.Length
                         }
                     };
@@ -193,13 +193,13 @@ namespace PrjFSLib.Linux.Interop
             uint nattrs);
 
         [StructLayout(LayoutKind.Sequential)]
-        public struct Event
+        public unsafe struct Event
         {
             public IntPtr Fs;
             public ulong Mask;
             public int Pid;
-            public IntPtr Path;
-            public IntPtr TargetPath;
+            public byte* Path;
+            public byte* TargetPath;
             public int Fd;
         }
 
@@ -212,10 +212,10 @@ namespace PrjFSLib.Linux.Interop
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        public struct Attr
+        public unsafe struct Attr
         {
-            public IntPtr Name;
-            public IntPtr Value;
+            public byte* Name;
+            public byte* Value;
             public long Size;
         }
     }

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/ProjFS.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/ProjFS.cs
@@ -59,8 +59,12 @@ namespace PrjFSLib.Linux.Interop
         public Result CreateProjFile(
             string relativePath,
             ulong fileSize,
-            uint fileMode)
+            uint fileMode,
+            byte[] providerId,
+            byte[] contentId)
         {
+            // TODO(Linux): create attr structs and pass to revised API
+
             return _CreateProjFile(
                 this.handle,
                 relativePath,
@@ -76,6 +80,15 @@ namespace PrjFSLib.Linux.Interop
                 this.handle,
                 relativePath,
                 symlinkTarget).ConvertErrnoToResult();
+        }
+
+        public Result GetProjAttrs(
+            string relativePath,
+            byte[] providerId,
+            byte[] contentId)
+        {
+            // TODO(Linux): read attr data using revised API
+            return Result.Success;
         }
 
         [DllImport(PrjFSLibPath, EntryPoint = "projfs_new")]


### PR DESCRIPTION
This is a parallel change which should be applied at the same time as github/libprojfs#60, and in conjunction with the revised libprojfs API, should now allow `MirrorProvider` to store and retrieve it's [dummy content and provider IDs](https://github.com/github/VFSForGit/blob/features/linuxprototype/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs#L117).  (And, at least in theory, should allow the `GVFS` provider to do the same.)

Note that I'm not looking to merge this into `vfs-api` yet; I'd like to do that at the same time as the corresponding libprojfs API changes are merged into master, and as I note in github/libprojfs#60 I'd like to get the test suite working there first.  But if you (@kivikakk) could give this a once-over for problems, I'd really appreciate it!