### PR TITLE
wait for mount (+ refactor)

### DIFF
--- a/GVFS/GVFS.Platform.Linux/LinuxFileSystem.cs
+++ b/GVFS/GVFS.Platform.Linux/LinuxFileSystem.cs
@@ -1,6 +1,6 @@
 using GVFS.Common;
 using GVFS.Platform.POSIX;
-using System;
+using PrjFSLib.Linux;
 using System.Runtime.InteropServices;
 
 namespace GVFS.Platform.Linux
@@ -19,98 +19,27 @@ namespace GVFS.Platform.Linux
 
         public override bool IsExecutable(string fileName)
         {
-            NativeStat.StatBuffer statBuffer = this.StatFile(fileName);
-            return NativeStat.IsExecutable(statBuffer.Mode);
+            LinuxNative.StatBuffer statBuffer = this.StatFile(fileName);
+            return LinuxNative.IsExecutable(statBuffer.Mode);
         }
 
         public override bool IsSocket(string fileName)
         {
-            NativeStat.StatBuffer statBuffer = this.StatFile(fileName);
-            return NativeStat.IsSock(statBuffer.Mode);
+            LinuxNative.StatBuffer statBuffer = this.StatFile(fileName);
+            return LinuxNative.IsSock(statBuffer.Mode);
         }
 
         [DllImport("libc", EntryPoint = "chmod", SetLastError = true)]
         private static extern int Chmod(string pathname, uint mode);
 
-        private NativeStat.StatBuffer StatFile(string fileName)
+        private LinuxNative.StatBuffer StatFile(string fileName)
         {
-            if (NativeStat.Stat(fileName, out NativeStat.StatBuffer statBuffer) != 0)
+            if (LinuxNative.Stat(fileName, out LinuxNative.StatBuffer statBuffer) != 0)
             {
                 NativeMethods.ThrowLastWin32Exception($"Failed to stat {fileName}");
             }
 
             return statBuffer;
-        }
-
-        private static class NativeStat
-        {
-            // #define  S_IFMT      0170000     /* [XSI] type of file mask */
-            private static readonly uint IFMT = Convert.ToUInt32("170000", 8);
-
-            // #define  S_IFSOCK    0140000     /* [XSI] socket */
-            private static readonly uint IFSOCK = Convert.ToUInt32("0140000", 8);
-
-            // #define S_IXUSR     0000100     /* [XSI] X for owner */
-            private static readonly uint IXUSR = Convert.ToUInt32("100", 8);
-
-            // #define S_IXGRP     0000010     /* [XSI] X for group */
-            private static readonly uint IXGRP = Convert.ToUInt32("10", 8);
-
-            // #define S_IXOTH     0000001     /* [XSI] X for other */
-            private static readonly uint IXOTH = Convert.ToUInt32("1", 8);
-
-            // #define _STAT_VER   1
-            private static readonly int STAT_VER = 1;
-
-            public static bool IsSock(uint mode)
-            {
-                // #define  S_ISSOCK(m) (((m) & S_IFMT) == S_IFSOCK)    /* socket */
-                return (mode & IFMT) == IFSOCK;
-            }
-
-            public static bool IsExecutable(uint mode)
-            {
-                return (mode & (IXUSR | IXGRP | IXOTH)) != 0;
-            }
-
-            public static int Stat(string path, [Out] out StatBuffer buf)
-            {
-                return __XStat64(STAT_VER, path, out buf);
-            }
-
-            // TODO(Linux): assumes recent GNU libc or ABI-compatible libc
-            [DllImport("libc", EntryPoint = "__xstat64", SetLastError = true)]
-            public static extern int __XStat64(int vers, string path, [Out] out StatBuffer buf);
-
-            [StructLayout(LayoutKind.Sequential)]
-            public struct TimeSpec
-            {
-                public long Sec;
-                public long Nsec;
-            }
-
-            // TODO(Linux): assumes stat64 field layout of x86-64 architecture
-            [StructLayout(LayoutKind.Sequential)]
-            public struct StatBuffer
-            {
-                public ulong Dev;           /* ID of device containing file */
-                public ulong Ino;           /* File serial number */
-                public ulong NLink;         /* Number of hard links */
-                public uint Mode;           /* Mode of file (see below) */
-                public uint UID;            /* User ID of the file */
-                public uint GID;            /* Group ID of the file */
-                public uint Padding;        /* RESERVED: DO NOT USE! */
-                public ulong RDev;          /* Device ID if special file */
-                public long Size;           /* file size, in bytes */
-                public long BlkSize;        /* optimal blocksize for I/O */
-                public long Blocks;         /* blocks allocated for file */
-                public TimeSpec ATimespec;  /* time of last access */
-                public TimeSpec MTimespec;  /* time of last data modification */
-                public TimeSpec CTimespec;  /* time of last status change */
-
-                [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)]
-                public long[] Reserved;     /* RESERVED: DO NOT USE! */
-            }
         }
 
         private static class NativeFileReader

--- a/GVFS/GVFS.Platform.Linux/LinuxFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Linux/LinuxFileSystemVirtualizer.cs
@@ -238,8 +238,6 @@ namespace GVFS.Platform.Linux
                 return false;
             }
 
-            // TODO(Linux): wait for device ID from stat() to change
-
             this.Context.Tracer.RelatedEvent(EventLevel.Informational, $"{nameof(this.TryStart)}_StartedVirtualization", metadata: null);
             return true;
         }

--- a/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
@@ -106,7 +106,7 @@ namespace MirrorProvider.Linux
                     else
                     {
                         string childRelativePath = Path.Combine(relativePath, child.Name);
-                        int statResult = NativeMethods.LStat(this.GetFullPathInMirror(childRelativePath), out NativeMethods.StatBuffer statBuffer);
+                        int statResult = LinuxNative.LStat(this.GetFullPathInMirror(childRelativePath), out LinuxNative.StatBuffer statBuffer);
                         if (statResult == -1)
                         {
                             Console.WriteLine($"NativeMethods.LStat failed: {Marshal.GetLastWin32Error()}");
@@ -260,51 +260,6 @@ namespace MirrorProvider.Linux
             bytes[0] = version;
 
             return bytes;
-        }
-
-        private static class NativeMethods
-        {
-            // #define _STAT_VER   1
-            private static readonly int STAT_VER = 1;
-
-            [StructLayout(LayoutKind.Sequential)]
-            public struct TimeSpec
-            {
-                public long Sec;
-                public long Nsec;
-            }
-
-            // TODO(Linux): assumes stat64 field layout of x86-64 architecture
-            [StructLayout(LayoutKind.Sequential)]
-            public struct StatBuffer
-            {
-                public ulong Dev;           /* ID of device containing file */
-                public ulong Ino;           /* File serial number */
-                public ulong NLink;         /* Number of hard links */
-                public uint Mode;           /* Mode of file (see below) */
-                public uint UID;            /* User ID of the file */
-                public uint GID;            /* Group ID of the file */
-                public uint Padding;        /* RESERVED: DO NOT USE! */
-                public ulong RDev;          /* Device ID if special file */
-                public long Size;           /* file size, in bytes */
-                public long BlkSize;        /* optimal blocksize for I/O */
-                public long Blocks;         /* blocks allocated for file */
-                public TimeSpec ATimespec;  /* time of last access */
-                public TimeSpec MTimespec;  /* time of last data modification */
-                public TimeSpec CTimespec;  /* time of last status change */
-
-                [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)]
-                public long[] Reserved;     /* RESERVED: DO NOT USE! */
-            }
-
-            public static int LStat(string pathname, [Out] out StatBuffer buf)
-            {
-                return __LXStat64(STAT_VER, pathname, out buf);
-            }
-
-            // TODO(Linux): assumes recent GNU libc or ABI-compatible libc
-            [DllImport("libc", EntryPoint = "__lxstat64", SetLastError = true)]
-            private static extern int __LXStat64(int vers, string pathname, [Out] out StatBuffer buf);
         }
 
         [DllImport("libc", EntryPoint = "readlink", SetLastError = true)]

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/LinuxNative.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/LinuxNative.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace PrjFSLib.Linux
+{
+    public static class LinuxNative
+    {
+        // #define  S_IFMT      0170000     /* [XSI] type of file mask */
+        private static readonly uint IFMT = Convert.ToUInt32("170000", 8);
+
+        // #define  S_IFSOCK    0140000     /* [XSI] socket */
+        private static readonly uint IFSOCK = Convert.ToUInt32("0140000", 8);
+
+        // #define S_IXUSR     0000100     /* [XSI] X for owner */
+        private static readonly uint IXUSR = Convert.ToUInt32("100", 8);
+
+        // #define S_IXGRP     0000010     /* [XSI] X for group */
+        private static readonly uint IXGRP = Convert.ToUInt32("10", 8);
+
+        // #define S_IXOTH     0000001     /* [XSI] X for other */
+        private static readonly uint IXOTH = Convert.ToUInt32("1", 8);
+
+        // #define _STAT_VER   1
+        private static readonly int STAT_VER = 1;
+
+        public static bool IsSock(uint mode)
+        {
+            // #define  S_ISSOCK(m) (((m) & S_IFMT) == S_IFSOCK)    /* socket */
+            return (mode & IFMT) == IFSOCK;
+        }
+
+        public static bool IsExecutable(uint mode)
+        {
+            return (mode & (IXUSR | IXGRP | IXOTH)) != 0;
+        }
+
+        public static int Stat(string path, [Out] out StatBuffer buf)
+        {
+            return __XStat64(STAT_VER, path, out buf);
+        }
+
+        public static int LStat(string pathname, [Out] out StatBuffer buf)
+        {
+            return __LXStat64(STAT_VER, pathname, out buf);
+        }
+
+        // TODO(Linux): assumes recent GNU libc or ABI-compatible libc
+        [DllImport("libc", EntryPoint = "__xstat64", SetLastError = true)]
+        private static extern int __XStat64(int vers, string path, [Out] out StatBuffer buf);
+
+        // TODO(Linux): assumes recent GNU libc or ABI-compatible libc
+        [DllImport("libc", EntryPoint = "__lxstat64", SetLastError = true)]
+        private static extern int __LXStat64(int vers, string pathname, [Out] out StatBuffer buf);
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct TimeSpec
+        {
+            public long Sec;
+            public long Nsec;
+        }
+
+        // TODO(Linux): assumes stat64 field layout of x86-64 architecture
+        [StructLayout(LayoutKind.Sequential)]
+        public struct StatBuffer
+        {
+            public ulong Dev;           /* ID of device containing file */
+            public ulong Ino;           /* File serial number */
+            public ulong NLink;         /* Number of hard links */
+            public uint Mode;           /* Mode of file (see below) */
+            public uint UID;            /* User ID of the file */
+            public uint GID;            /* Group ID of the file */
+            public uint Padding;        /* RESERVED: DO NOT USE! */
+            public ulong RDev;          /* Device ID if special file */
+            public long Size;           /* file size, in bytes */
+            public long BlkSize;        /* optimal blocksize for I/O */
+            public long Blocks;         /* blocks allocated for file */
+            public TimeSpec ATimespec;  /* time of last access */
+            public TimeSpec MTimespec;  /* time of last data modification */
+            public TimeSpec CTimespec;  /* time of last status change */
+
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)]
+            private long[] reserved;     /* RESERVED: DO NOT USE! */
+        }
+    }
+}

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 using PrjFSLib.Linux.Interop;
 using static PrjFSLib.Linux.Interop.Errno;
 
@@ -10,6 +11,9 @@ namespace PrjFSLib.Linux
     public class VirtualizationInstance
     {
         public const int PlaceholderIdLength = 128;
+
+        private static readonly TimeSpan MountWaitTick = TimeSpan.FromSeconds(0.2);
+        private static readonly TimeSpan MountWaitTotal = TimeSpan.FromSeconds(30);
 
         private ProjFS projfs;
         private int currentProcessId = Process.GetCurrentProcess().Id;
@@ -42,6 +46,14 @@ namespace PrjFSLib.Linux
                 throw new InvalidOperationException();
             }
 
+            int statResult = LinuxNative.Stat(virtualizationRootFullPath, out LinuxNative.StatBuffer stat);
+            if (statResult != 0)
+            {
+                return Result.Invalid;
+            }
+
+            ulong priorDev = stat.Dev;
+
             ProjFS.Handlers handlers = new ProjFS.Handlers
             {
                 HandleProjEvent = this.preventGCOnProjEventDelegate = new ProjFS.EventHandler(this.HandleProjEvent),
@@ -65,8 +77,28 @@ namespace PrjFSLib.Linux
                 return Result.Invalid;
             }
 
+            Stopwatch watch = Stopwatch.StartNew();
+
+            while (true)
+            {
+                statResult = LinuxNative.Stat(virtualizationRootFullPath, out stat);
+                if (priorDev != stat.Dev)
+                {
+                    break;
+                }
+
+                Thread.Sleep(MountWaitTick);
+
+                if (watch.Elapsed > MountWaitTotal)
+                {
+                    fs.Stop();
+                    return Result.Invalid;
+                }
+            }
+
             this.projfs = fs;
             this.virtualizationRoot = virtualizationRootFullPath;
+
             return Result.Success;
         }
 


### PR DESCRIPTION
* refactor the Linux native calls out of `GVFS.Platform.Linux.LinuxFileSystem` and `MirrorProvider.Linux.LinuxFileSystemVirtualizer` into `PrjFSLib.Linux.LinuxNative`
  * I originally wanted to call this `PrjFSLib.Linux.NativeMethods`, but that causes a name conflict with `GVFS.Common.NativeMethods` if you import both namespaces at once. Of course, we could use full names in that case, but it's easier to read if we just call them different things.
* add the `stat` loop per #12 
  * I put it in `LinuxFileSystemVirtualizer` in fa75efa, but that broke all our unit tests -- it's expected that the actual filesystem calls will be mocked out by using the `MockVirtualizationInstance`, so the `stat` loop fails.
  * Accordingly, 0080708 (what a SHA!) shifts the logic into `PrjFSLib.Linux.VirtualizationInstance`.